### PR TITLE
Ensure JSON serializer normalize* hooks get called

### DIFF
--- a/addon/mixin.js
+++ b/addon/mixin.js
@@ -104,9 +104,8 @@ export default Ember.Mixin.create({
     return meta;
   },
 
-  normalizeResponse (store, primaryModelClass, payload, id, requestType) {
-    const isSingle = this.isSinglePayload(payload, requestType),
-      documentHash = {},
+  _normalizeResponse (store, primaryModelClass, payload, id, requestType, isSingle) {
+    const documentHash = {},
       meta = this.extractMeta(store, requestType, payload, primaryModelClass),
       included = [];
 


### PR DESCRIPTION
This is a bit of a hack (overriding a private method instead of a public one from DS.JSONSerializer) but should hold together for now.

See here for how JSONSerializer dispatches from normalizeResponse:

https://github.com/emberjs/data/blob/v1.13.15/packages/ember-data/lib/serializers/json-serializer.js#L223
